### PR TITLE
Customize Q0 Max as a macro pad

### DIFF
--- a/keyboards/keychron/common/wireless/bat_level_animation.c
+++ b/keyboards/keychron/common/wireless/bat_level_animation.c
@@ -28,6 +28,14 @@
 #    define LED_DRIVER_IS_ENABLED rgb_matrix_is_enabled
 #endif
 
+#ifndef BAT_LEVEL_LED_LIST_SIZE
+#    define BAT_LEVEL_LED_LIST_SIZE 10
+#endif
+
+#ifndef BAT_LEVEL_STEP
+#    define BAT_LEVEL_STEP 10
+#endif
+
 enum {
     BAT_LVL_ANI_NONE,
     BAT_LVL_ANI_GROWING,
@@ -71,26 +79,38 @@ bool bat_level_animiation_actived(void) {
 
 void bat_level_animiation_indicate(void) {
 #ifdef LED_MATRIX_ENABLE
-    uint8_t  bat_lvl_led_list[10] = BAT_LEVEL_LED_LIST;
+    uint8_t  bat_lvl_led_list[BAT_LEVEL_LED_LIST_SIZE] = BAT_LEVEL_LED_LIST;
 
+#ifdef BAT_LEVEL_ANIMATION_NO_CLEAR_ALL
+    for (uint8_t i = 0; i < BAT_LEVEL_LED_LIST_SIZE; i++) {
+        led_matrix_set_value(bat_lvl_led_list[i], 0);
+    }
+#else
     for (uint8_t i = 0; i <= LED_MATRIX_LED_COUNT; i++) {
         led_matrix_set_value(i, 0);
     }
+#endif
 
     if (animation_state == BAT_LVL_ANI_GROWING || animation_state == BAT_LVL_ANI_BLINK_ON)
-        for (uint8_t i = 0; i < cur_percentage / 10; i++)
+        for (uint8_t i = 0; i < cur_percentage / BAT_LEVEL_STEP; i++)
             led_matrix_set_value(bat_lvl_led_list[i], 255);
 #endif
 
 #ifdef RGB_MATRIX_ENABLE
-    uint8_t  bat_lvl_led_list[10] = BAT_LEVEL_LED_LIST;
+    uint8_t  bat_lvl_led_list[BAT_LEVEL_LED_LIST_SIZE] = BAT_LEVEL_LED_LIST;
 
+#ifdef BAT_LEVEL_ANIMATION_NO_CLEAR_ALL
+    for (uint8_t i = 0; i < BAT_LEVEL_LED_LIST_SIZE; i++) {
+        rgb_matrix_set_color(bat_lvl_led_list[i], 0, 0, 0);
+    }
+#else
     for (uint8_t i = 0; i <= RGB_MATRIX_LED_COUNT; i++) {
         rgb_matrix_set_color(i, 0, 0, 0);
     }
+#endif
 
     if (animation_state == BAT_LVL_ANI_GROWING || animation_state == BAT_LVL_ANI_BLINK_ON) {
-        for (uint8_t i = 0; i < cur_percentage / 10; i++) {
+        for (uint8_t i = 0; i < cur_percentage / BAT_LEVEL_STEP; i++) {
             rgb_matrix_set_color(bat_lvl_led_list[i], r, g, b);
         }
     }
@@ -101,9 +121,9 @@ void bat_level_animiation_update(void) {
     switch (animation_state) {
         case BAT_LVL_ANI_GROWING:
             if (cur_percentage < bat_percentage)
-                cur_percentage += 10;
+                cur_percentage += BAT_LEVEL_STEP;
             else {
-                if (cur_percentage == 0) cur_percentage = 10;
+                if (cur_percentage == 0) cur_percentage = BAT_LEVEL_STEP;
                 animation_state = BAT_LVL_ANI_BLINK_OFF;
             }
             break;

--- a/keyboards/keychron/q0_max/encoder/config.h
+++ b/keyboards/keychron/q0_max/encoder/config.h
@@ -47,12 +47,19 @@
 
 /* Indications */
 #    define NUM_LOCK_INDEX	        5
+#    define HOMING_KEY_INDEX            16
 #    define MACRO_LAYER_INDEX           16
+#    define BORDER_LED_LIST             { 0, 1, 2, 3, 4, 8, 9, 13, 14, 18, 22, 23, 24, 25 }
+#    define BORDER_LED_LIST_SIZE        14
 #    define LOW_BAT_IND_INDEX           { 23 }
 #    define BAT_LEVEL_LED_LIST          { 23, 18, 14, 9, 4 }
 #    define BAT_LEVEL_LED_LIST_SIZE     5  // size of BAT_LEVEL_LED_LIST
 #    define BAT_LEVEL_STEP              20 // 100 / BAT_LEVEL_LED_LIST_SIZE
 #    define BAT_LEVEL_ANIMATION_NO_CLEAR_ALL
+
+/* Default animation */
+#    define RGB_MATRIX_DEFAULT_MODE RGB_MATRIX_CUSTOM_homing_keys_bkg
+#    define RGB_MATRIX_DEFAULT_HUE  168
 
 #    define RGB_MATRIX_KEYPRESSES
 #    define RGB_MATRIX_FRAMEBUFFER_EFFECTS

--- a/keyboards/keychron/q0_max/encoder/config.h
+++ b/keyboards/keychron/q0_max/encoder/config.h
@@ -59,7 +59,7 @@
 
 /* Default RGB Matrix config */
 #    define RGB_MATRIX_DEFAULT_MODE RGB_MATRIX_CUSTOM_homing_keys_bkg
-#    define RGB_MATRIX_DEFAULT_HUE  168
+#    define RGB_MATRIX_DEFAULT_HUE  169
 
 #    define RGB_MATRIX_KEYPRESSES
 #    define RGB_MATRIX_FRAMEBUFFER_EFFECTS

--- a/keyboards/keychron/q0_max/encoder/config.h
+++ b/keyboards/keychron/q0_max/encoder/config.h
@@ -57,7 +57,7 @@
 #    define BAT_LEVEL_STEP              20 // 100 / BAT_LEVEL_LED_LIST_SIZE
 #    define BAT_LEVEL_ANIMATION_NO_CLEAR_ALL
 
-/* Default animation */
+/* Default RGB Matrix config */
 #    define RGB_MATRIX_DEFAULT_MODE RGB_MATRIX_CUSTOM_homing_keys_bkg
 #    define RGB_MATRIX_DEFAULT_HUE  168
 

--- a/keyboards/keychron/q0_max/encoder/config.h
+++ b/keyboards/keychron/q0_max/encoder/config.h
@@ -46,8 +46,12 @@
 #    define RGB_MATRIX_BRIGHTNESS_TURN_OFF_VAL 32
 
 /* Indications */
-#    define NUM_LOCK_INDEX	5
-#    define LOW_BAT_IND_INDEX { 24 }
+#    define NUM_LOCK_INDEX	        5
+#    define LOW_BAT_IND_INDEX           { 23 }
+#    define BAT_LEVEL_LED_LIST          { 23, 18, 14, 9, 4 }
+#    define BAT_LEVEL_LED_LIST_SIZE     5  // size of BAT_LEVEL_LED_LIST
+#    define BAT_LEVEL_STEP              20 // 100 / BAT_LEVEL_LED_LIST_SIZE
+#    define BAT_LEVEL_ANIMATION_NO_CLEAR_ALL
 
 #    define RGB_MATRIX_KEYPRESSES
 #    define RGB_MATRIX_FRAMEBUFFER_EFFECTS

--- a/keyboards/keychron/q0_max/encoder/config.h
+++ b/keyboards/keychron/q0_max/encoder/config.h
@@ -47,6 +47,7 @@
 
 /* Indications */
 #    define NUM_LOCK_INDEX	        5
+#    define MACRO_LAYER_INDEX           16
 #    define LOW_BAT_IND_INDEX           { 23 }
 #    define BAT_LEVEL_LED_LIST          { 23, 18, 14, 9, 4 }
 #    define BAT_LEVEL_LED_LIST_SIZE     5  // size of BAT_LEVEL_LED_LIST

--- a/keyboards/keychron/q0_max/encoder/keymaps/via/keymap.c
+++ b/keyboards/keychron/q0_max/encoder/keymaps/via/keymap.c
@@ -53,7 +53,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______, RGB_MOD,  RGB_VAI, RGB_HUI, _______,
         _______, RGB_RMOD, RGB_VAD, RGB_HUD, _______,
         _______, RGB_SAI,  RGB_SPI, KC_MPRV,
-        _______, RGB_SAD,  RGB_SPD, KC_MPLY, _______,
+        _______, RGB_SAD,  RGB_SPD, KC_MPLY, BAT_LVL,
         _______, RGB_TOG,           KC_MNXT          ),
 
     [L2] = LAYOUT_tenkey_27(

--- a/keyboards/keychron/q0_max/encoder/keymaps/via/keymap.c
+++ b/keyboards/keychron/q0_max/encoder/keymaps/via/keymap.c
@@ -17,29 +17,44 @@
 #include QMK_KEYBOARD_H
 #include "keychron_common.h"
 
+#define MC_LCK  C(G(KC_Q))  // Lock screen
+#define MC_SELA LSG(KC_L)   // Select all occurrences
+#define MC_LEND LSA(KC_I)   // Add cursor to line ends
+#define MC_SELN G(KC_L)     // Select line
+#define MC_DELN LSG(KC_K)   // Delete line
+#define MC_UTAB S(KC_TAB)   // Untab
+#define MC_SAVE G(KC_S)     // Save
+#define MC_UNDO G(KC_Z)     // Undo
+#define MC_REDO LSG(KC_Z)   // Redo
+#define MC_CUT  G(KC_X)     // Cut
+#define MC_COPY G(KC_C)     // Copy
+#define MC_PAST G(KC_V)     // Paste
+#define MC_CLIP LSG(KC_V)   // Open clipboard history
+#define MC_COMT G(KC_SLSH)  // Comment line
+
 enum layers {
     BASE,
     FN,
     L2,
-    L3,
+    MACRO,
 };
 // clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [BASE] = LAYOUT_tenkey_27(
-        KC_MUTE, KC_ESC, KC_DEL, KC_TAB, KC_BSPC,
-        MC_1,	 KC_NUM, KC_PSLS,KC_PAST,KC_PMNS,
-        MC_2,	 KC_P7,	 KC_P8,	 KC_P9,	 KC_PPLS,
-        MC_3,	 KC_P4,	 KC_P5,	 KC_P6,
-        MC_4,	 KC_P1,	 KC_P2,	 KC_P3,	 KC_PENT,
-        MO(FN),  KC_P0,          KC_PDOT         ),
+        KC_MUTE,   KC_ESC, TO(MACRO), KC_BSPC, KC_DEL,
+        TO(MACRO), KC_NUM, KC_PSLS,   KC_PAST, KC_PMNS,
+        KC_NO,     KC_P7,  KC_P8,	  KC_P9,   KC_PPLS,
+        KC_NO,	   KC_P4,  KC_P5,	  KC_P6,
+        KC_NO,	   KC_P1,  KC_P2,	  KC_P3,   KC_PENT,
+        MO(FN),    KC_P0,             KC_PDOT          ),
 
     [FN] = LAYOUT_tenkey_27(
-        RGB_TOG, BT_HST1, BT_HST2, BT_HST3, P2P4G,
-        _______, RGB_MOD, RGB_VAI, RGB_HUI, _______,
-        _______, RGB_RMOD,RGB_VAD, RGB_HUD, _______,
-        _______, RGB_SAI, RGB_SPI, KC_MPRV,
-        _______, RGB_SAD, RGB_SPD, KC_MPLY, _______,
-        _______, RGB_TOG,          KC_MNXT          ),
+        RGB_TOG, BT_HST1,  BT_HST2, BT_HST3, P2P4G,
+        _______, RGB_MOD,  RGB_VAI, RGB_HUI, _______,
+        _______, RGB_RMOD, RGB_VAD, RGB_HUD, _______,
+        _______, RGB_SAI,  RGB_SPI, KC_MPRV,
+        _______, RGB_SAD,  RGB_SPD, KC_MPLY, _______,
+        _______, RGB_TOG,           KC_MNXT          ),
 
     [L2] = LAYOUT_tenkey_27(
         _______, _______, _______, _______, _______,
@@ -49,22 +64,22 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______, _______, _______, _______, _______,
         _______, _______,          _______          ),
 
-    [L3] = LAYOUT_tenkey_27(
-        _______, _______, _______, _______, _______,
-        _______, _______, _______, _______, _______,
-        _______, _______, _______, _______, _______,
-        _______, _______, _______, _______,
-        _______, _______, _______, _______, _______,
-        _______, _______,          _______          )
+    [MACRO] = LAYOUT_tenkey_27(
+        KC_NO,    KC_ESC,  TO(BASE), KC_BSPC, KC_DEL,
+        KC_NO,    KC_NO,   KC_NO,    KC_NO,   KC_NO,
+        MC_SELA,  MC_UTAB, KC_TAB,   KC_NO,   MC_SAVE,
+        MC_LEND,  MC_UNDO, MC_REDO,  KC_NO,
+        MC_SELN,  MC_CUT,  MC_COPY,  MC_PAST, KC_PENT,
+        MC_DELN,  MC_CLIP,           MC_COMT          )
 };
 
 // clang-format on
 #if defined(ENCODER_MAP_ENABLE)
 const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][2] = {
-    [BASE] = {ENCODER_CCW_CW(KC_VOLD, KC_VOLU)},
-    [FN]   = {ENCODER_CCW_CW(RGB_VAD, RGB_VAI)},
-    [L2]   = {ENCODER_CCW_CW(KC_VOLD, KC_VOLU)},
-    [L3]   = {ENCODER_CCW_CW(RGB_VAD, RGB_VAI)},
+    [BASE]  = {ENCODER_CCW_CW(KC_VOLD, KC_VOLU)},
+    [FN]    = {ENCODER_CCW_CW(RGB_VAD, RGB_VAI)},
+    [L2]    = {ENCODER_CCW_CW(KC_VOLD, KC_VOLU)},
+    [MACRO] = {ENCODER_CCW_CW(KC_NO, KC_NO)},
 };
 #endif // ENCODER_MAP_ENABLE
 

--- a/keyboards/keychron/q0_max/encoder/keymaps/via/keymap.c
+++ b/keyboards/keychron/q0_max/encoder/keymaps/via/keymap.c
@@ -89,3 +89,13 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     }
     return true;
 }
+
+bool rgb_matrix_indicators_user(void) {
+    switch (get_highest_layer(layer_state)) {
+        case MACRO:
+            rgb_matrix_set_color(MACRO_LAYER_INDEX, RGB_RED);
+            break;
+    }
+
+    return false;
+}

--- a/keyboards/keychron/q0_max/encoder/keymaps/via/keymap.c
+++ b/keyboards/keychron/q0_max/encoder/keymaps/via/keymap.c
@@ -41,12 +41,12 @@ enum layers {
 // clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [BASE] = LAYOUT_tenkey_27(
-        KC_MUTE,   KC_ESC, TO(MACRO), KC_BSPC, KC_DEL,
-        TO(MACRO), KC_NUM, KC_PSLS,   KC_PAST, KC_PMNS,
-        KC_NO,     KC_P7,  KC_P8,	  KC_P9,   KC_PPLS,
-        KC_NO,	   KC_P4,  KC_P5,	  KC_P6,
-        KC_NO,	   KC_P1,  KC_P2,	  KC_P3,   KC_PENT,
-        MO(FN),    KC_P0,             KC_PDOT          ),
+        KC_MUTE, KC_ESC, TO(MACRO), KC_BSPC, KC_DEL,
+        KC_NO,   KC_NUM, KC_PSLS,   KC_PAST, KC_PMNS,
+        KC_NO,   KC_P7,  KC_P8,	    KC_P9,   KC_PPLS,
+        KC_NO,	 KC_P4,  KC_P5,	    KC_P6,
+        KC_NO,	 KC_P1,  KC_P2,	    KC_P3,   KC_PENT,
+        MO(FN),  KC_P0,             KC_PDOT          ),
 
     [FN] = LAYOUT_tenkey_27(
         RGB_TOG, BT_HST1,  BT_HST2, BT_HST3, P2P4G,
@@ -90,7 +90,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     return true;
 }
 
-bool rgb_matrix_indicators_user(void) {
+bool rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
     switch (get_highest_layer(layer_state)) {
         case MACRO:
             rgb_matrix_set_color(MACRO_LAYER_INDEX, RGB_RED);

--- a/keyboards/keychron/q0_max/encoder/keymaps/via/rgb_matrix_user.inc
+++ b/keyboards/keychron/q0_max/encoder/keymaps/via/rgb_matrix_user.inc
@@ -1,0 +1,33 @@
+RGB_MATRIX_EFFECT(highlight_homing_keys)
+RGB_MATRIX_EFFECT(homing_keys_bkg)
+
+#ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+
+static bool highlight_homing_keys(effect_params_t* params) {
+  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+
+  RGB rgb = rgb_matrix_hsv_to_rgb(rgb_matrix_config.hsv);
+
+  rgb_matrix_set_color(HOMING_KEY_INDEX, rgb.r, rgb.g, rgb.b);
+
+  return rgb_matrix_check_finished_leds(led_max);
+}
+
+static bool homing_keys_bkg(effect_params_t* params) {
+  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+
+  rgb_matrix_set_color_all(RGB_OFF);
+
+  uint8_t border_led_list[BORDER_LED_LIST_SIZE] = BORDER_LED_LIST;
+
+  for (uint8_t i = 0; i < BORDER_LED_LIST_SIZE; i++) {
+    rgb_matrix_set_color(border_led_list[i], 0x6a, 0xb4, 0xff);
+  }
+
+  RGB rgb = rgb_matrix_hsv_to_rgb(rgb_matrix_config.hsv);
+  rgb_matrix_set_color(HOMING_KEY_INDEX, rgb.r, rgb.g, rgb.b);
+
+  return rgb_matrix_check_finished_leds(led_max);
+}
+
+#endif

--- a/keyboards/keychron/q0_max/encoder/keymaps/via/rules.mk
+++ b/keyboards/keychron/q0_max/encoder/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+RGB_MATRIX_CUSTOM_USER = yes

--- a/keyboards/keychron/q0_max/via_json/q0_max_encoder.json
+++ b/keyboards/keychron/q0_max/via_json/q0_max_encoder.json
@@ -23,6 +23,8 @@
               "options": [
                 ["None", 0],
                 ["Solid Color", 1],
+                ["Highlight Homing Keys", 23],
+                ["Homing Keys Over Blue", 24],
                 ["Breathing", 2],
                 ["Band Spiral Val", 3],
                 ["Cycle All", 4],
@@ -47,14 +49,14 @@
               ]
             },
             {
-              "showIf": "{id_qmk_rgb_matrix_effect} > 1",
+              "showIf": "{id_qmk_rgb_matrix_effect} >= 2 && {id_qmk_rgb_matrix_effect} <= 22",
               "label": "Effect Speed",
               "type": "range",
               "options": [0, 255],
               "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
             },
             {
-              "showIf": "{id_qmk_rgb_matrix_effect} != 0 && ( {id_qmk_rgb_matrix_effect} < 4 || {id_qmk_rgb_matrix_effect} == 18 || ({id_qmk_rgb_matrix_effect} > 17 && {id_qmk_rgb_matrix_effect} != 21) ) ",
+              "showIf": "({id_qmk_rgb_matrix_effect} >= 1 && {id_qmk_rgb_matrix_effect} <= 3) || ({id_qmk_rgb_matrix_effect} >= 18 && {id_qmk_rgb_matrix_effect} <= 20) || {id_qmk_rgb_matrix_effect} >= 22",
               "label": "Color",
               "type": "color",
               "content": ["id_qmk_rgb_matrix_color", 3, 4]
@@ -80,7 +82,8 @@
     {"name": "Bluetooth Host 1", "title": "Bluetooth Host 1", "shortName": "BTH1"},
     {"name": "Bluetooth Host 2", "title": "Bluetooth Host 2", "shortName": "BTH2"},
     {"name": "Bluetooth Host 3", "title": "Bluetooth Host 3", "shortName": "BTH3"},
-    {"name": "2.4G", "title": "2.4G", "shortName": "2.4G"}
+    {"name": "2.4G", "title": "2.4G", "shortName": "2.4G"},
+    {"name": "Battery level", "title": "Battery level", "shortName": "BatLvl"}
   ],
   "layouts": {
     "keymap":[


### PR DESCRIPTION
- [x] Set macro pad layer in keymap
- [x] Adapt battery level check animation for Q0 Max
- [x] Add RGB macro layer indicator
- [x] Add custom animation for transparent homing keys
